### PR TITLE
feat: add summarizing script

### DIFF
--- a/summarize_list.py
+++ b/summarize_list.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+# author: github.com/a37h
+# 2019
+
+kInputFileName = 'README.md'
+kNameLinkSeparator = '	'  # current symbol is a tab which will cause output to be split into 2 colums in Excel
+kLinesSeparator = '\n'  # current symbol is a newline which will cause output to be split into rows in Excel
+kOutputFile = 'README_processed.txt' 
+# OUTPUT_FILE = None  # uncomment this not to save any output to file
+
+
+readme = [x.strip() for x in open(kInputFileName, 'r')]
+if kOutputFile:
+    out = open(kOutputFile, 'w')
+
+
+# remove the unnecessary stuff
+for i in range(len(readme)):
+    if '|---|---|---|---|' in readme[0]:
+        break
+    else:
+        del readme[0]
+del readme[0]
+
+
+# process each line and gather company name and applying link
+for row in readme:
+    r = [x.strip() for x in row.split('|')][1:-1]
+    company = r[0].split('](')
+    name, link = company[0][1:], company[1][:-1]
+    print(name, link, sep=kNameLinkSeparator, end=kLinesSeparator)
+
+    if kOutputFile:
+        out.write(name + kNameLinkSeparator + link + kLinesSeparator)


### PR DESCRIPTION
Should work with any `Python 3` version
Being run on `README.md` outputs a list of company's names and application links looking like:
```
user@pc:~/summer2020internships$ python3 summarize_list.py 
IMC Trading	https://imc.wd5.myworkdayjobs.com/invitation/job/Chicago/Quant-Trader-Intern---Summer-2020_REQ-00550
Ebay	https://jobs.ebayinc.com/job/san-jose/software-engineer-intern/403/13338627
Esri	https://www.esri.com/en-us/about/careers/job-detail?jobID=11338&mode=job&iis=Job%2BBoard&iisn=LinkedIn
```

The output format is suitable for copy-pasting it into an Excel document, `company name` and `application link` will automatically be split into 2 columns, which is quite convenient